### PR TITLE
Fixes TypeError: 'NoneType' object is not iterable error.

### DIFF
--- a/docqa/triviaqa/answer_detection.py
+++ b/docqa/triviaqa/answer_detection.py
@@ -237,6 +237,8 @@ def compute_answer_spans(questions: List[TriviaQaQuestion], corpus, word_tokeniz
         if len(tokenized_aliases) == 0:
             raise ValueError()
         detector.set_question(tokenized_aliases)
+        if q.all_docs is None:
+            continue
         for doc in q.all_docs:
             text = corpus.get_document(doc.doc_id)
             if text is None:

--- a/docqa/triviaqa/build_span_corpus.py
+++ b/docqa/triviaqa/build_span_corpus.py
@@ -56,6 +56,8 @@ def build_dataset(name: str, tokenizer, train_files: Dict[str, str],
         for q in questions:  # Sanity check, we should have answers for everything (even if of size 0)
             if q.answer is None:
                 continue
+            if q.all_docs is None:
+                continue
             for doc in q.all_docs:
                 if doc.doc_id in file_map:
                     if doc.answer_spans is None:


### PR DESCRIPTION
Fixed the following error while running the `build_span_corpus.py` script on TriviaQA dataset - 

Command:
`python docqa/triviaqa/build_span_corpus.py wiki --n_processes 8`

Error:
 ```
File "docqa/triviaqa/build_span_corpus.py", line 59, in build_dataset
    for doc in q.all_docs:
TypeError: 'NoneType' object is not iterable
```
```
File "/home/document-qa/docqa/triviaqa/answer_detection.py", line 241, in compute_answer_spans
    for doc in q.all_docs:
TypeError: 'NoneType' object is not iterable
```