### PR TITLE
changed default batch size to fix error

### DIFF
--- a/docqa/eval/squad_eval.py
+++ b/docqa/eval/squad_eval.py
@@ -41,7 +41,7 @@ def main():
                         help="(for testing) run on a subset of questions")
     parser.add_argument('--answer_bounds', nargs='+', type=int, default=[17],
                         help="Max size of answer")
-    parser.add_argument('-b', '--batch_size', type=int, default=200,
+    parser.add_argument('-b', '--batch_size', type=int, default=128,
                         help="Batch size, larger sizes can be faster but uses more memory")
     parser.add_argument('-s', '--step', default=None,
                         help="Weights to load, can be a checkpoint step or 'latest'")


### PR DESCRIPTION
Had to change the default batch size here to correspond to the training batch size for elmo. However, I understand that the default of 200 might be necessary for other models.

Here was the error message:
Traceback (most recent call last):
  File "docqa/eval/squad_eval.py", line 115, in <module>
    main()
  File "docqa/eval/squad_eval.py", line 88, in main
    corpus.get_resource_loader(), checkpoint, not args.no_ema)[args.corpus]
  File "newqa/document-qa/docqa/trainer.py", line 682, in test
    dataset_outputs[name] = evaluator_runner.run_evaluators(sess, dataset, name, sample, {})
  File "newqa/document-qa/docqa/evaluator.py", line 390, in run_evaluators
    feed_dict = self.model.encode(batch, is_train=False)
  File "newqa/document-qa/docqa/elmo/lm_qa_models.py", line 211, in encode
    (self.max_batch_size, len(batch)))
ValueError: The model can only use a batch <= 128, but got 200